### PR TITLE
Water bug

### DIFF
--- a/cg_mapping/charmm_mappings/C16FFA.xml
+++ b/cg_mapping/charmm_mappings/C16FFA.xml
@@ -1,11 +1,11 @@
 <Mapping>
   <Molecule name="C16FFA">
     <Beads n_beads="6">
-      <Bead beadtype="C1" index="0" map="0 1 2"/>
-      <Bead beadtype="C1" index="1" map="3 4 5"/>
-      <Bead beadtype="C1" index="2" map="6 7 8"/>
-      <Bead beadtype="C1" index="3" map="9 10 11"/>
-      <Bead beadtype="C1" index="4" map="12 13 14"/>
+      <Bead beadtype="C3" index="0" map="0 1 2"/>
+      <Bead beadtype="C3" index="1" map="3 4 5"/>
+      <Bead beadtype="C3" index="2" map="6 7 8"/>
+      <Bead beadtype="C3" index="3" map="9 10 11"/>
+      <Bead beadtype="C3" index="4" map="12 13 14"/>
       <Bead beadtype="P3" index="5" map="15 16 17 18"/>
     </Beads>
     <Bonds n_bonds="5">

--- a/cg_mapping/charmm_mappings/C16FFA.xml
+++ b/cg_mapping/charmm_mappings/C16FFA.xml
@@ -1,0 +1,19 @@
+<Mapping>
+  <Molecule name="C16FFA">
+    <Beads n_beads="6">
+      <Bead beadtype="C1" index="0" map="0 1 2"/>
+      <Bead beadtype="C1" index="1" map="3 4 5"/>
+      <Bead beadtype="C1" index="2" map="6 7 8"/>
+      <Bead beadtype="C1" index="3" map="9 10 11"/>
+      <Bead beadtype="C1" index="4" map="12 13 14"/>
+      <Bead beadtype="P3" index="5" map="15 16 17 18"/>
+    </Beads>
+    <Bonds n_bonds="5">
+      <Bond bead1="0" bead2="1"/>
+      <Bond bead1="1" bead2="2"/>
+      <Bond bead1="2" bead2="3"/>
+      <Bond bead1="3" bead2="4"/>
+      <Bond bead1="4" bead2="5"/>
+    </Bonds>
+  </Molecule>
+</Mapping>

--- a/cg_mapping/charmm_mappings/chol.xml
+++ b/cg_mapping/charmm_mappings/chol.xml
@@ -1,0 +1,58 @@
+<Mapping>
+  <Molecule name="chol">
+    <Beads n_beads="11">
+      <Bead beadtype="chead" index="0" map="0 2"/>
+      <Bead beadtype="ring" index="1" map="0 1 15 16 17 18"/>
+      <Bead beadtype="ring" index="2" map="4 5 6 7 8 9 10"/>
+      <Bead beadtype="ring" index="3" map="26 27 28 29 30 31 32 33"/>
+      <Bead beadtype="ring" index="4" map="34 47 48"/>
+      <Bead beadtype="ring" index="5" map="39 40 41 42 43 44 45 46"/>
+      <Bead beadtype="ring" index="6" map="19 20 21 22 23 24 25"/>
+      <Bead beadtype="ctail" index="7" map="49 50 51 52 53 54 55 56 57 58 59 60"/>
+      <Bead beadtype="cterm" index="8" map="61 62 63 64 65 66 67 68 69 70 71 72 73"/>
+      <Bead beadtype="chme" index="9" map="11 12 13 14"/>
+      <Bead beadtype="chme" index="10" map="35 36 37 38"/>
+    </Beads>
+    <Bonds n_bonds="39">
+      <Bond bead1="0" bead2="1"/>
+      <Bond bead1="1" bead2="2"/>
+      <Bond bead1="1" bead2="6"/>
+      <Bond bead1="2" bead2="3"/>
+      <Bond bead1="2" bead2="9"/>
+      <Bond bead1="3" bead2="4"/>
+      <Bond bead1="3" bead2="6"/>
+      <Bond bead1="4" bead2="5"/>
+      <Bond bead1="4" bead2="7"/>
+      <Bond bead1="4" bead2="10"/>
+      <Bond bead1="5" bead2="6"/>
+      <Bond bead1="7" bead2="8"/>
+      <Bond bead1="0" bead2="3"/>
+      <Bond bead1="0" bead2="4"/>
+      <Bond bead1="0" bead2="5"/>
+      <Bond bead1="0" bead2="7"/>
+      <Bond bead1="0" bead2="8"/>
+      <Bond bead1="0" bead2="9"/>
+      <Bond bead1="0" bead2="10"/>
+      <Bond bead1="1" bead2="4"/>
+      <Bond bead1="1" bead2="7"/>
+      <Bond bead1="1" bead2="8"/>
+      <Bond bead1="1" bead2="10"/>
+      <Bond bead1="2" bead2="5"/>
+      <Bond bead1="2" bead2="7"/>
+      <Bond bead1="2" bead2="8"/>
+      <Bond bead1="2" bead2="10"/>
+      <Bond bead1="3" bead2="8"/>
+      <Bond bead1="4" bead2="9"/>
+      <Bond bead1="5" bead2="8"/>
+      <Bond bead1="5" bead2="9"/>
+      <Bond bead1="6" bead2="7"/>
+      <Bond bead1="6" bead2="8"/>
+      <Bond bead1="6" bead2="9"/>
+      <Bond bead1="6" bead2="10"/>
+      <Bond bead1="7" bead2="9"/>
+      <Bond bead1="8" bead2="9"/>
+      <Bond bead1="8" bead2="10"/>
+      <Bond bead1="9" bead2="10"/>
+    </Bonds>
+  </Molecule>
+</Mapping>

--- a/cg_mapping/charmm_mappings/write_chol_xml.py
+++ b/cg_mapping/charmm_mappings/write_chol_xml.py
@@ -1,0 +1,80 @@
+from lxml import etree
+
+
+outputFile = "chol.xml"
+root = etree.Element('Mapping')
+mapping = etree.SubElement(root,"Molecule", name=outputFile[:-4])
+beadtypes = etree.SubElement(mapping, 'Beads')
+bonds = etree.SubElement(mapping, 'Bonds')
+
+etree.SubElement(beadtypes, "Bead", index="0", beadtype='chead',
+        map='0 2')
+etree.SubElement(beadtypes, "Bead", index="1", beadtype='ring',
+    map='0 1 15 16 17 18')
+etree.SubElement(beadtypes, "Bead", index="2", beadtype='ring',
+    map='4 5 6 7 8 9 10')
+etree.SubElement(beadtypes, "Bead", index="3", beadtype='ring',
+    map='26 27 28 29 30 31 32 33')
+etree.SubElement(beadtypes, "Bead", index="4", beadtype='ring',
+    map='34 47 48')
+etree.SubElement(beadtypes, "Bead", index="5", beadtype='ring',
+    map='39 40 41 42 43 44 45 46')
+etree.SubElement(beadtypes, "Bead", index="6", beadtype='ring',
+    map='19 20 21 22 23 24 25')
+etree.SubElement(beadtypes, "Bead", index="7", beadtype='ctail',
+    map='49 50 51 52 53 54 55 56 57 58 59 60')
+etree.SubElement(beadtypes, "Bead", index="8", beadtype='cterm',
+    map='61 62 63 64 65 66 67 68 69 70 71 72 73')
+etree.SubElement(beadtypes, "Bead", index="9", beadtype='chme',
+    map='11 12 13 14')
+etree.SubElement(beadtypes, "Bead", index="10", beadtype='chme',
+    map='35 36 37 38')
+
+etree.SubElement(bonds, 'Bond', bead1='0', bead2='1')
+etree.SubElement(bonds, 'Bond', bead1='1', bead2='2')
+etree.SubElement(bonds, 'Bond', bead1='1', bead2='6')
+etree.SubElement(bonds, 'Bond', bead1='2', bead2='3')
+etree.SubElement(bonds, 'Bond', bead1='2', bead2='9')
+etree.SubElement(bonds, 'Bond', bead1='3', bead2='4')
+etree.SubElement(bonds, 'Bond', bead1='3', bead2='6')
+etree.SubElement(bonds, 'Bond', bead1='4', bead2='5')
+etree.SubElement(bonds, 'Bond', bead1='4', bead2='7')
+etree.SubElement(bonds, 'Bond', bead1='4', bead2='10')
+etree.SubElement(bonds, 'Bond', bead1='5', bead2='6')
+etree.SubElement(bonds, 'Bond', bead1='7', bead2='8')
+etree.SubElement(bonds, 'Bond', bead1='0', bead2='3')
+etree.SubElement(bonds, 'Bond', bead1='0', bead2='4')
+etree.SubElement(bonds, 'Bond', bead1='0', bead2='5')
+etree.SubElement(bonds, 'Bond', bead1='0', bead2='7')
+etree.SubElement(bonds, 'Bond', bead1='0', bead2='8')
+etree.SubElement(bonds, 'Bond', bead1='0', bead2='9')
+etree.SubElement(bonds, 'Bond', bead1='0', bead2='10')
+etree.SubElement(bonds, 'Bond', bead1='1', bead2='4')
+etree.SubElement(bonds, 'Bond', bead1='1', bead2='7')
+etree.SubElement(bonds, 'Bond', bead1='1', bead2='8')
+etree.SubElement(bonds, 'Bond', bead1='1', bead2='10')
+etree.SubElement(bonds, 'Bond', bead1='2', bead2='5')
+etree.SubElement(bonds, 'Bond', bead1='2', bead2='7')
+etree.SubElement(bonds, 'Bond', bead1='2', bead2='8')
+etree.SubElement(bonds, 'Bond', bead1='2', bead2='10')
+etree.SubElement(bonds, 'Bond', bead1='3', bead2='8')
+etree.SubElement(bonds, 'Bond', bead1='4', bead2='9')
+etree.SubElement(bonds, 'Bond', bead1='5', bead2='8')
+etree.SubElement(bonds, 'Bond', bead1='5', bead2='9')
+etree.SubElement(bonds, 'Bond', bead1='6', bead2='7')
+etree.SubElement(bonds, 'Bond', bead1='6', bead2='8')
+etree.SubElement(bonds, 'Bond', bead1='6', bead2='9')
+etree.SubElement(bonds, 'Bond', bead1='6', bead2='10')
+etree.SubElement(bonds, 'Bond', bead1='7', bead2='9')
+etree.SubElement(bonds, 'Bond', bead1='8', bead2='9')
+etree.SubElement(bonds, 'Bond', bead1='8', bead2='10')
+etree.SubElement(bonds, 'Bond', bead1='9', bead2='10')
+
+
+
+
+
+bonds.set('n_bonds', str(len(bonds.getchildren())))
+beadtypes.set('n_beads', str(len(beadtypes.getchildren())))
+tree =  etree.ElementTree(root)
+tree.write(outputFile, pretty_print=True)

--- a/cg_mapping/charmm_mappings/write_dppc_xml.py
+++ b/cg_mapping/charmm_mappings/write_dppc_xml.py
@@ -1,0 +1,65 @@
+from lxml import etree
+
+# This is a hard-coded script to desing the DSPC.xml file
+
+outputFile = "DPPC.xml"
+root = etree.Element('Mapping')
+mapping = etree.SubElement(root,"Molecule", name=outputFile[:-4])
+beadtypes = etree.SubElement(mapping, 'Beads')
+bonds = etree.SubElement(mapping, 'Bonds')
+
+# Add beads
+etree.SubElement(beadtypes, "Bead", index="0", beadtype='PCN', 
+                map="0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15")
+etree.SubElement(beadtypes, "Bead", index="1", beadtype='PCP',
+                map="16 17 18 19 20 21 22 23 24 25 26")
+# Tail A
+etree.SubElement(beadtypes, "Bead", index="2", beadtype="E1",
+                map="27 28 29 30 31")
+# Tail B
+etree.SubElement(beadtypes, "Bead", index="3", beadtype="E1",
+                map="35 36 37 38 39 40")
+# Tail A
+etree.SubElement(beadtypes, "Bead", index="4", beadtype="C3",
+                map="32 33 34 44 45 46 47 48 49")
+etree.SubElement(beadtypes, "Bead", index="5", beadtype="C3",
+                map="50 51 52 53 54 55 56 57 58")
+etree.SubElement(beadtypes, "Bead", index="6", beadtype="C3",
+                map="59 60 61 62 63 64 65 66 67")
+etree.SubElement(beadtypes, "Bead", index="7", beadtype="C3",
+                map="68 69 70 71 72 73 74 75 76")
+etree.SubElement(beadtypes, "Bead", index="8", beadtype="C3",
+                map="77 78 79 80 81 82 83 84 85 86")
+# Tail B
+etree.SubElement(beadtypes, "Bead", index="9", beadtype="C3",
+                map="41 42 43 87 88 89 90 91 92")
+etree.SubElement(beadtypes, "Bead", index="10", beadtype="C3",
+                map="93 94 95 96 97 98 99 100 101")
+etree.SubElement(beadtypes, "Bead", index="11", beadtype="C3",
+                map="102 103 104 105 106 107 108 109 110")
+etree.SubElement(beadtypes, "Bead", index="12", beadtype="C3",
+                map="111 112 113 114 115 116 117 118 119")
+etree.SubElement(beadtypes, "Bead", index="13", beadtype="C3",
+                map="120 121 123 124 125 126 127 128 129")
+
+
+# Add bonds
+etree.SubElement(bonds, "Bond", bead1="0", bead2="1")
+etree.SubElement(bonds, "Bond", bead1="1", bead2="2")
+etree.SubElement(bonds, "Bond", bead1="2", bead2="3")
+etree.SubElement(bonds, "Bond", bead1="2", bead2="4")
+etree.SubElement(bonds, "Bond", bead1="4", bead2="5")
+etree.SubElement(bonds, "Bond", bead1="5", bead2="6")
+etree.SubElement(bonds, "Bond", bead1="6", bead2="7")
+etree.SubElement(bonds, "Bond", bead1="7", bead2="8")
+etree.SubElement(bonds, "Bond", bead1="3", bead2="9")
+etree.SubElement(bonds, "Bond", bead1="9", bead2="10")
+etree.SubElement(bonds, "Bond", bead1="10", bead2="11")
+etree.SubElement(bonds, "Bond", bead1="11", bead2="12")
+etree.SubElement(bonds, "Bond", bead1="12", bead2="13")
+
+
+bonds.set('n_bonds', str(len(bonds.getchildren())))
+beadtypes.set('n_beads', str(len(beadtypes.getchildren())))
+tree =  etree.ElementTree(root)
+tree.write(outputFile, pretty_print=True)

--- a/cg_mapping/mapping_functions.py
+++ b/cg_mapping/mapping_functions.py
@@ -184,7 +184,7 @@ def create_CG_topology(topol=None, all_CG_mappings=None, water_bead_mapping=4,
 
     return CG_topology_map, CG_topology
 
-def _map_waters(traj, water_start, frame_index):
+def _map_waters(traj, frame_index):
     """ Worker function to parallelize mapping waters via kmeans
 
     Parameters
@@ -193,9 +193,7 @@ def _map_waters(traj, water_start, frame_index):
         full atomstic trajectory
     frame index : int
         parallelizing calculation frame by frame
-    water_start : int
-        counter denoting which index in the CG coordiantes is water
-
+    
     """
     from sklearn import cluster
     frame = traj[frame_index]
@@ -228,7 +226,7 @@ def _map_waters(traj, water_start, frame_index):
     # For each cluster, compute enter of mass
     for cg_index, water_cluster in enumerate(water_clusters):
         com = mdtraj.compute_center_of_mass(frame.atom_slice(water_cluster))
-        single_frame_coms.append((frame_index, cg_index+water_start, com))
+        single_frame_coms.append((frame_index, com))
         #CG_xyz[frame_index, cg_index + water_start,:] = com
     return single_frame_coms
  
@@ -258,7 +256,6 @@ def convert_xyz(traj=None, CG_topology_map=None, water_bead_mapping=4,parallel=T
     water_indices = []
     print("Converting non-water atoms into beads over all frames")
     start = time.time()
-    nonwater_index = 0
     for index, bead in enumerate(CG_topology_map):
         if 'HOH' not in bead.resname:
             # Handle non-water residuse with center of mass calculation over all frames
@@ -270,8 +267,6 @@ def convert_xyz(traj=None, CG_topology_map=None, water_bead_mapping=4,parallel=T
             # Handle waters by initially setting the bead coordinates to zero
             # Remember which coarse grain indices correspond to water
             water_indices.append(index)
-            #CG_xyz[:,index,:] = np.zeros((traj.n_frames,3))
-            #water_index +=1
 
     end = time.time()
     print("Converting took: {}".format(end-start))
@@ -280,10 +275,6 @@ def convert_xyz(traj=None, CG_topology_map=None, water_bead_mapping=4,parallel=T
     print("Converting water beads via k-means")
     start = time.time()
     if len(water_indices)>0:
-        #water_start = min(water_indices)
-        water_start = nonwater_index + 1
-
-
         # Perform kmeans, frame-by-frame, over all water residues
         # Workers will return centers of masses of clusters, frame index, and cg index
         # Master will assign to CG_xyz
@@ -291,7 +282,7 @@ def convert_xyz(traj=None, CG_topology_map=None, water_bead_mapping=4,parallel=T
             all_frame_coms = []
             with Pool() as p:
                 all_frame_coms = p.starmap(_map_waters, zip(itertools.repeat(traj), 
-                    itertools.repeat(water_start), range(traj.n_frames)))
+                                        range(traj.n_frames)))
 
             end = time.time()
             print("K-means and converting took: {}".format(end-start))
@@ -299,12 +290,8 @@ def convert_xyz(traj=None, CG_topology_map=None, water_bead_mapping=4,parallel=T
             print("Writing to CG-xyz")
             start = time.time()
             for snapshot in all_frame_coms:
-                for element,water_index in zip(snapshot, 
-                                                water_indices):
-                    #CG_xyz[element[0],element[1],:] = element[2]
-                    print(element)
-                    print(element[2].shape)
-                    CG_xyz[element[0], water_index , : ] = element[2]
+                for element, water_index in zip(snapshot, water_indices):
+                    CG_xyz[element[0], water_index , : ] = element[1]
             end =  time.time()
             print("Writing took: {}".format(end-start))
 

--- a/cg_mapping/mapping_functions.py
+++ b/cg_mapping/mapping_functions.py
@@ -258,18 +258,21 @@ def convert_xyz(traj=None, CG_topology_map=None, water_bead_mapping=4,parallel=T
     water_indices = []
     print("Converting non-water atoms into beads over all frames")
     start = time.time()
+    nonwater_index = 0
     for index, bead in enumerate(CG_topology_map):
         if 'HOH' not in bead.resname:
             # Handle non-water residuse with center of mass calculation over all frames
             atom_indices = bead.atom_indices 
             # Two ways to compute center of mass, both are pretty fast
             bead_coordinates = mdtraj.compute_center_of_mass(traj.atom_slice(atom_indices))
-            CG_xyz[:, index, :] = bead_coordinates
+            CG_xyz[:, nonwater_index, :] = bead_coordinates
+            nonwater_index +=1 
         else:
             # Handle waters by initially setting the bead coordinates to zero
             # Remember which coarse grain indices correspond to water
             water_indices.append(index)
-            CG_xyz[:,index,:] = np.zeros((traj.n_frames,3))
+            #CG_xyz[:,index,:] = np.zeros((traj.n_frames,3))
+            #water_index +=1
 
     end = time.time()
     print("Converting took: {}".format(end-start))
@@ -278,7 +281,8 @@ def convert_xyz(traj=None, CG_topology_map=None, water_bead_mapping=4,parallel=T
     print("Converting water beads via k-means")
     start = time.time()
     if len(water_indices)>0:
-        water_start = min(water_indices)
+        #water_start = min(water_indices)
+        water_start = nonwater_index
 
 
         # Perform kmeans, frame-by-frame, over all water residues

--- a/cg_mapping/mapping_functions.py
+++ b/cg_mapping/mapping_functions.py
@@ -208,7 +208,7 @@ def _map_waters(traj, water_start, frame_index):
 
     # Number of CG water molecules based on mapping scheme
     water_bead_mapping = 4
-    n_cg_water = int(n_aa_water /  water_bead_mapping)
+    n_cg_water = int(np.floor(n_aa_water /  water_bead_mapping))
     # Water clusters are a list (n_cg_water) of empty lists
     water_clusters = [[] for i in range(n_cg_water)]
 

--- a/cg_mapping/mappings/convert_map_to_xml.py
+++ b/cg_mapping/mappings/convert_map_to_xml.py
@@ -1,8 +1,8 @@
 from lxml import etree
 import pdb
 
-inputFile = "DSPC.map"
-outputFile = "DSPC.xml"
+inputFile = "C16FFA.map"
+outputFile = "C16FFA.xml"
 root = etree.Element('Mapping')
 mapping = etree.SubElement(root,"Molecule", name=outputFile[:-4])
 beadtypes = etree.SubElement(mapping, 'Beads')

--- a/cg_mapping/scripts/get_bonded_parameters.py
+++ b/cg_mapping/scripts/get_bonded_parameters.py
@@ -12,8 +12,9 @@ import argparse
 and compute bond/angle parameters by fitting to
 Gaussian distributions"""
 #beadtypes=['P4', 'P3', 'Nda', 'E1', 'C2', 'C3', 'PCP', 'PCN']
-beadtypes=['_CH3', '_CH2']
+#beadtypes=['_CH3', '_CH2']
 #beadtypes=['P4', 'P3', 'Nda', 'Na', 'C2', 'C1', 'Qa', 'Q0']
+beadtypes=['W', 'P3', 'Nda', 'E1', 'C2', 'C3', 'PCP', 'PCN']
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-f", dest="trajectory", help="Trajectory")


### PR DESCRIPTION
* When adding coordinates of coarse-grain beads, the CG index was taken to be the last non-water bead index. This logic fails when you have non-consecutive, non-water beads (i.e. molecule 1, water, molecule 1, water).
* This fix should assign water coordinates to the indices in which they were formed in the CG topology. Namely, CG waters were created whenever a running list of 4 waters was filled. When enumerating through the topology, the k-means XYZ coordinates will follow that ordering